### PR TITLE
NPM audit fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "version-healthcheck",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,689 @@
+{
+  "name": "version-healthcheck",
+  "version": "0.1.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "0.1.16",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "dev": true,
+      "requires": {
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
+      },
+      "dependencies": {
+        "underscore.string": {
+          "version": "2.4.0",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/underscore.string/-/underscore.string-2.4.0.tgz",
+          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+          "dev": true
+        }
+      }
+    },
+    "async": {
+      "version": "0.1.22",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/async/-/async-0.1.22.tgz",
+      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+      "dev": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.1",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+      "integrity": "sha1-vj5TgvwCttYySVasGvmKqYsIU0w=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/bytes/-/bytes-0.2.0.tgz",
+      "integrity": "sha1-qtM+wU49wsp06OfUUfm6BTrU96A=",
+      "dev": true
+    },
+    "cli": {
+      "version": "0.4.5",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/cli/-/cli-0.4.5.tgz",
+      "integrity": "sha1-ePlIXNFhtWbppsctcXDEJw6B22E=",
+      "dev": true,
+      "requires": {
+        "glob": ">= 3.1.4"
+      }
+    },
+    "coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+      "dev": true
+    },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "dev": true
+    },
+    "commander": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/commander/-/commander-1.2.0.tgz",
+      "integrity": "sha1-/VcTv6FTx9bMWZN4patMRcU1Ap4=",
+      "dev": true,
+      "requires": {
+        "keypress": "0.1.x"
+      }
+    },
+    "connect": {
+      "version": "2.8.8",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/connect/-/connect-2.8.8.tgz",
+      "integrity": "sha1-uav4yvC9l3PLPeopNEEZhyWCRG0=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "0.2.1",
+        "bytes": "0.2.0",
+        "cookie": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*",
+        "formidable": "1.0.14",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "pause": "0.0.1",
+        "qs": "0.6.5",
+        "send": "0.1.4",
+        "uid2": "0.0.2"
+      }
+    },
+    "console-browserify": {
+      "version": "0.1.6",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/console-browserify/-/console-browserify-0.1.6.tgz",
+      "integrity": "sha1-0SijwLuINQ61YmxufHGm8P1ImDw=",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/cookie/-/cookie-0.1.0.tgz",
+      "integrity": "sha1-kOtGndzpBchm3mh+/EMTHYgB+dA=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/cookie-signature/-/cookie-signature-1.0.1.tgz",
+      "integrity": "sha1-ROByFIrwHm6OJK+/EmkNaK5pjss=",
+      "dev": true
+    },
+    "cookiejar": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/cookiejar/-/cookiejar-1.3.0.tgz",
+      "integrity": "sha1-3QCzVnkCHpnL1OhVua0EGRNHR2U=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+      "dev": true
+    },
+    "debug": {
+      "version": "4.3.3",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deep-equal": {
+      "version": "0.0.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/deep-equal/-/deep-equal-0.0.0.tgz",
+      "integrity": "sha1-mWedO70EcVb81FDT0B7rkGhpHoM=",
+      "dev": true
+    },
+    "defined": {
+      "version": "0.0.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+      "dev": true
+    },
+    "emitter-component": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/emitter-component/-/emitter-component-1.0.0.tgz",
+      "integrity": "sha1-8E3Rj8PcPpp0y8DzELCIZm5MAW8=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "dev": true
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "express": {
+      "version": "3.3.8",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/express/-/express-3.3.8.tgz",
+      "integrity": "sha1-jpisMNgfTJW4XXHSr2z4T2LvGb0=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "0.2.1",
+        "commander": "1.2.0",
+        "connect": "2.8.8",
+        "cookie": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "mkdirp": "0.3.5",
+        "range-parser": "0.0.4",
+        "send": "0.1.4"
+      }
+    },
+    "findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+      "dev": true,
+      "requires": {
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2",
+            "minimatch": "0.3"
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
+        }
+      }
+    },
+    "formidable": {
+      "version": "1.0.14",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/formidable/-/formidable-1.0.14.tgz",
+      "integrity": "sha1-Kz9MQRy7X91pXESEPiojUUpDIxo=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/fresh/-/fresh-0.2.0.tgz",
+      "integrity": "sha1-v9lALPPfEsSkwxDHn5mj3eE9NKc=",
+      "dev": true
+    },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.1.21",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+      "dev": true
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "dev": true,
+      "requires": {
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      }
+    },
+    "grunt-contrib-jshint": {
+      "version": "0.6.5",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/grunt-contrib-jshint/-/grunt-contrib-jshint-0.6.5.tgz",
+      "integrity": "sha1-OvtGdnRTZMxKGe7nk0wOBgCLVm4=",
+      "dev": true,
+      "requires": {
+        "jshint": "~2.1.10"
+      }
+    },
+    "grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "dev": true,
+      "requires": {
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "dev": true,
+      "requires": {
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+      "dev": true,
+      "requires": {
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      }
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "dev": true,
+      "requires": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      }
+    },
+    "jshint": {
+      "version": "2.1.11",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/jshint/-/jshint-2.1.11.tgz",
+      "integrity": "sha1-61EI/vm6Xd67gwmD9XLSQuSeP5Y=",
+      "dev": true,
+      "requires": {
+        "cli": "0.4.x",
+        "console-browserify": "0.1.x",
+        "minimatch": "0.x.x",
+        "shelljs": "0.1.x",
+        "underscore": "1.4.x"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.4.4",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/underscore/-/underscore-1.4.4.tgz",
+          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+          "dev": true
+        }
+      }
+    },
+    "json-stringify-safe": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/json-stringify-safe/-/json-stringify-safe-4.0.0.tgz",
+      "integrity": "sha1-d8JxqupUMC5o7+rMtWq78GqbGlQ=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "keypress": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/keypress/-/keypress-0.1.0.tgz",
+      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "0.9.2",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "methods": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/methods/-/methods-0.0.1.tgz",
+      "integrity": "sha1-J3yQ+L7zlwlkWoNxxRw7bGSOBow=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.2.11",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+      "dev": true
+    },
+    "mout": {
+      "version": "1.2.3",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/mout/-/mout-1.2.3.tgz",
+      "integrity": "sha1-vRR32Mfy21/PQ8kd4wtsx0a3jhA="
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "optimist": {
+      "version": "0.5.2",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/optimist/-/optimist-0.5.2.tgz",
+      "integrity": "sha1-hcjBRUszFeSniUfoV7HfAzRQv7w=",
+      "dev": true,
+      "requires": {
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=",
+      "dev": true
+    },
+    "qconf": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/qconf/-/qconf-0.2.0.tgz",
+      "integrity": "sha1-jl2sXHWn7jUzZXMn3Zjf5/Vn32g=",
+      "dev": true,
+      "requires": {
+        "optimist": "~0.5.0",
+        "stampit": "~0.5.1"
+      },
+      "dependencies": {
+        "mout": {
+          "version": "0.5.0",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/mout/-/mout-0.5.0.tgz",
+          "integrity": "sha1-/5Z1ZqkPKVlenLi254AKW1ZjVYM=",
+          "dev": true
+        },
+        "stampit": {
+          "version": "0.5.1",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/stampit/-/stampit-0.5.1.tgz",
+          "integrity": "sha1-7vda9Rsz8fm0UpIpOvhURmAsvbo=",
+          "dev": true,
+          "requires": {
+            "json-stringify-safe": "~4.0.0",
+            "mout": "~0.5.0"
+          }
+        }
+      }
+    },
+    "qs": {
+      "version": "0.6.5",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/qs/-/qs-0.6.5.tgz",
+      "integrity": "sha1-KUsmjksNQlD23eGbO4s0k13/FO8=",
+      "dev": true
+    },
+    "range-parser": {
+      "version": "0.0.4",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/range-parser/-/range-parser-0.0.4.tgz",
+      "integrity": "sha1-wEJ//vUcEKy6B4KkbJYC50T/Ygs=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "dev": true
+    },
+    "send": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/send/-/send-0.1.4.tgz",
+      "integrity": "sha1-vnDY0b4B3mGCGvE3gLUDRaT3Gr0=",
+      "dev": true,
+      "requires": {
+        "debug": "*",
+        "fresh": "0.2.0",
+        "mime": "~1.2.9",
+        "range-parser": "0.0.4"
+      }
+    },
+    "shelljs": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/shelljs/-/shelljs-0.1.4.tgz",
+      "integrity": "sha1-37vnjVbDwBaNL7eeEOzR28sH7A4=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "stampit": {
+      "version": "4.3.2",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/stampit/-/stampit-4.3.2.tgz",
+      "integrity": "sha1-z9P2B91iihYc5jBWIVl5lLTVZXM="
+    },
+    "superagent": {
+      "version": "0.15.1",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/superagent/-/superagent-0.15.1.tgz",
+      "integrity": "sha1-8N+ZVMK5DynkrlStMI5KK0MsxWo=",
+      "dev": true,
+      "requires": {
+        "cookiejar": "1.3.0",
+        "debug": "~0.7.2",
+        "emitter-component": "1.0.0",
+        "formidable": "1.0.9",
+        "methods": "0.0.1",
+        "mime": "1.2.5",
+        "qs": "0.6.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+          "dev": true
+        },
+        "formidable": {
+          "version": "1.0.9",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/formidable/-/formidable-1.0.9.tgz",
+          "integrity": "sha1-QZ47zOrT6IdNU59bPnKkxQOzGpg=",
+          "dev": true
+        },
+        "mime": {
+          "version": "1.2.5",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/mime/-/mime-1.2.5.tgz",
+          "integrity": "sha1-nu0HMCKov14WyFZsaGe4gyv7+hM=",
+          "dev": true
+        }
+      }
+    },
+    "supertest": {
+      "version": "0.7.1",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/supertest/-/supertest-0.7.1.tgz",
+      "integrity": "sha1-NJplqL+1IHJQZY9xdhJ5rTpnHYg=",
+      "dev": true,
+      "requires": {
+        "methods": "0.0.1",
+        "superagent": "0.15.1"
+      }
+    },
+    "tape": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/tape/-/tape-1.0.4.tgz",
+      "integrity": "sha1-4ujlxt0/AP3CpeRRT2L8Ih5Z+cQ=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "~0.0.0",
+        "defined": "~0.0.0",
+        "jsonify": "~0.0.0",
+        "through": "~2.3.4"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "uid2": {
+      "version": "0.0.2",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/uid2/-/uid2-0.0.2.tgz",
+      "integrity": "sha1-EH+xVcgsETZiB5ftTIjPKwj2qrg=",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+      "dev": true
+    },
+    "underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.0.9",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/which/-/which-1.0.9.tgz",
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "version-healthcheck",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A plug-and-play /version route for the Node.js Express framework.",
   "main": "version.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "mout": "~0.6.0",
-    "stampit": "~0.5.1"
+    "mout": "^1.2.3",
+    "stampit": "^4.3.2"
   }
 }

--- a/version.js
+++ b/version.js
@@ -39,7 +39,7 @@ var path = require('path'),
     return instance;
   };
 
-version = stampit().enclose(function () {
+version = stampit.init(function () {
   var handler = function (req, res) {
     var options = handler.options,
       pkg = options.pkg || readPkg(),


### PR DESCRIPTION
There is an `npm audit` issue with the versions of mout/stampit which you are using. Updated the packages. The only breaking change I could find is the call to `stampit().enclose` which is deprecated.